### PR TITLE
Fixed Instance indexing jarvisclient.py

### DIFF
--- a/jlclient/jarvisclient.py
+++ b/jlclient/jarvisclient.py
@@ -244,8 +244,8 @@ class User(object):
     @classmethod
     def get_instance(cls, instance_id=None):
         assert instance_id != None, 'pass a valid instance/machine id'
-        instance = [instance for instance in User.get_instances() if str(instance['machine_id']) == str(instance_id)]
-        return Instance(**instance[0])
+        instance = [instance for instance in User.get_instances() if str(instance.machine_id) == str(instance_id)]
+        return instance[0]
     
     @classmethod
     def get_templates(cls):


### PR DESCRIPTION
User.get_instance() is expecting User.get_instances() to return dicts instead of Instance classes. This causes the pause() function in JLClient documentation to throw an error. Also referenced in this issue: https://github.com/jarvislabsai/JLClient/issues/8#issue-2347435997